### PR TITLE
Adjustment to EMB v0.9 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Version 0.8.1 (2025-02-10)
+
+* Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):
+  * Increased version nubmer for EMB.
+  * Model worked without adjustments.
+  * Adjustments only required for simple understanding of changes.
+
 ## Version 0.8.0 (2024-12-05)
 
 ### Rework of stack replacement

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.8.3"
+EnergyModelsBase = "0.9.0"
 EnergyModelsInvestments = "0.8"
 JuMP = "1.5"
 julia = "1.10"

--- a/examples/electrolyzer.jl
+++ b/examples/electrolyzer.jl
@@ -92,13 +92,9 @@ function generate_electrolyzer_example_data()
         Direct("electrolyzer-h2_demand", nodes[2], nodes[3], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -114,8 +110,8 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_elec_results(m, case)
     # Extract the nodes and the strategic periods from the data
-    elect = case[:nodes][2]
-    𝒯ᴵⁿᵛ = strategic_periods(case[:T])
+    elect = get_nodes(case)[2]
+    𝒯ᴵⁿᵛ = strategic_periods(get_time_struct(case))
 
     # Extract the first operational period of each strategic period
     first_op = [first(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ]

--- a/examples/h2_storage.jl
+++ b/examples/h2_storage.jl
@@ -110,13 +110,8 @@ function generate_h2_storage_example_data()
         Direct("h2_storage-h2_demand", nodes[3], nodes[4], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -127,9 +122,9 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_h2_stor_results(m, case)
     # Extract the nodes and the first strategic period from the data
-    supply, h2_stor = case[:nodes][[2,3]]           # Extract the h2 supply and storage node
-    Power = case[:products][1]                      # Extract the electricity resource
-    sp1 = collect(strategic_periods(case[:T]))[1]   # Extract the first strategic period
+    supply, h2_stor = get_nodes(case)[[2,3]]           # Extract the h2 supply and storage node
+    Power = get_products(case)[1]                      # Extract the electricity resource
+    sp1 = collect(strategic_periods(get_time_struct(case)))[1]   # Extract the first strategic period
 
     # Extracting the different pressures and calculate the multiplier
     pₘᵢₙ = EMH.p_min(h2_stor)

--- a/examples/reformer.jl
+++ b/examples/reformer.jl
@@ -133,13 +133,8 @@ function generate_refomer_example_data()
         Direct("reformer-co2_storage", nodes[3], nodes[5], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -150,8 +145,8 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_ref_results(m, case)
     # Extract the nodes and the first strategic period from the data
-    reformer, demand = case[:nodes][[3,4]]          # Extract the reformer and demand node
-    sp1 = collect(strategic_periods(case[:T]))[1]   # Extract the first strategic period
+    reformer, demand = get_nodes(case)[[3,4]]          # Extract the reformer and demand node
+    sp1 = collect(strategic_periods(get_time_struct(case)))[1]   # Extract the first strategic period
 
     # Reformer variables
     load = JuMP.Containers.rowtable(                # Capacity utilization

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -64,12 +64,7 @@ function simple_graph_elec(;
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = Dict(
-                :T => T,
-                :nodes => nodes,
-                :links => links,
-                :products => resources,
-    )
+    case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
     return create_model(case, model), case, model
 end
 
@@ -171,12 +166,7 @@ function simple_graph_ref(;
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = Dict(
-                :T => T,
-                :nodes => nodes,
-                :links => links,
-                :products => resources,
-    )
+    case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
     return create_model(case, model), case, model
 end
 
@@ -280,12 +270,7 @@ function simple_graph_simple_stor(;
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = Dict(
-                :T => T,
-                :nodes => nodes,
-                :links => links,
-                :products => resources,
-    )
+    case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
     return create_model(case, model), case, model
 end
 
@@ -372,12 +357,7 @@ function simple_graph_h2_stor(;
         Dict(CO2 => FixedProfile(0)),
         CO2,
     )
-    case = Dict(
-                :T => T,
-                :nodes => nodes,
-                :links => links,
-                :products => resources,
-    )
+    case = Case(T, resources, [nodes, links], [[get_nodes, get_links]])
     return create_model(case, model), case, model
 end
 

--- a/test/test_electrolyzer.jl
+++ b/test/test_electrolyzer.jl
@@ -54,8 +54,8 @@ end
     penalty_test(m, data, params_inv)
 
     # Reassign types
-    elect = data[:nodes][3]
-    𝒯     = data[:T]
+    elect = get_nodes(data)[3]
+    𝒯     = get_time_struct(data)
     𝒯ᴵⁿᵛ = EMB.strategic_periods(𝒯)
 
     # Test that there are no quadratic constraints for SimpleElectrolyzer types
@@ -82,8 +82,8 @@ end
     penalty_test(m, data, params_stack)
 
     # Reassign types
-    elect = data[:nodes][3]
-    𝒯     = data[:T]
+    elect = get_nodes(data)[3]
+    𝒯     = get_time_struct(data)
     𝒯ᴵⁿᵛ = EMB.strategic_periods(𝒯)
     stack_replace = m[:elect_stack_replace_b][elect, :]
 
@@ -119,8 +119,8 @@ end
     penalty_test(m, data, params_rep)
 
     # Reassign types
-    elect = data[:nodes][3]
-    𝒯     = data[:T]
+    elect = get_nodes(data)[3]
+    𝒯     = get_time_struct(data)
     𝒯ᴵⁿᵛ = EMB.strategic_periods(𝒯)
     stack_replace = m[:elect_stack_replace_b][elect, :]
 
@@ -148,9 +148,9 @@ end
     penalty_test(m, data, params_elec)
 
     # Reassign types
-    elect = data[:nodes][3]
-    hydrogen = data[:products][2]
-    𝒯     = data[:T]
+    elect = get_nodes(data)[3]
+    hydrogen = get_products(data)[2]
+    𝒯     = get_time_struct(data)
     𝒯ᴵⁿᵛ = EMB.strategic_periods(𝒯)
     stack_replace = m[:elect_stack_replace_b][elect, :]
 

--- a/test/test_h2_storage.jl
+++ b/test/test_h2_storage.jl
@@ -22,12 +22,10 @@ params_dict = Dict(
     (m, case) = build_run_h2_storage_model(params_used)
 
     # Extract the sets and variables
-    power = case[:products][1]
-    h2 = case[:products][2]
-    h2_stor = case[:nodes][3]
-    h2_demand = case[:nodes][4]
+    power, h2 = get_products(case)[[1,2]]
+    h2_stor, h2_demand = get_nodes(case)[[3,4]]
     flow_in = value.(m[:flow_in][h2_stor, :, :])
-    𝒯 = case[:T]
+    𝒯 = get_time_struct(case)
 
     # Test that the electricity demand is correctly included
     # (showing that we do not need a new function)
@@ -94,12 +92,10 @@ end
         (m, case) = build_run_h2_storage_model(params_used)
 
         # Extract the sets and variables
-        power = case[:products][1]
-        h2 = case[:products][2]
-        h2_stor = case[:nodes][3]
-        h2_demand = case[:nodes][4]
+        power, h2 = get_products(case)[[1,2]]
+        h2_stor, h2_demand = get_nodes(case)[[3,4]]
         flow_in = value.(m[:flow_in][h2_stor, :, :])
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
 
         # Save the results
         flow_el[:equal] = [flow_in[t, power] for t ∈ 𝒯]
@@ -130,12 +126,10 @@ end
         (m, case) = build_run_h2_storage_model(params_used)
 
         # Extract the sets and variables
-        power = case[:products][1]
-        h2 = case[:products][2]
-        h2_stor = case[:nodes][3]
-        h2_demand = case[:nodes][4]
+        power, h2 = get_products(case)[[1,2]]
+        h2_stor, h2_demand = get_nodes(case)[[3,4]]
         flow_in = value.(m[:flow_in][h2_stor, :, :])
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
 
         # Save the results
         flow_el[:lower] = [flow_in[t, power] for t ∈ 𝒯]
@@ -170,12 +164,10 @@ end
         (m, case) = build_run_h2_storage_model(params_used)
 
         # Extract the sets and variables
-        power = case[:products][1]
-        h2 = case[:products][2]
-        h2_stor = case[:nodes][3]
-        h2_demand = case[:nodes][4]
+        power, h2 = get_products(case)[[1,2]]
+        h2_stor, h2_demand = get_nodes(case)[[3,4]]
         flow_in = value.(m[:flow_in][h2_stor, :, :])
-        𝒯 = case[:T]
+        𝒯 = get_time_struct(case)
 
         # Save the results
         flow_el[:higher] = [flow_in[t, power] for t ∈ 𝒯]

--- a/test/test_reformer.jl
+++ b/test/test_reformer.jl
@@ -37,8 +37,8 @@ end
     reformer_test(m, case, params_used)
 
     # Extract the required parameters
-    𝒯 = case[:T]
-    ref = case[:nodes][3]
+    𝒯 = get_time_struct(case)
+    ref = get_nodes(case)[3]
     ops = collect(𝒯)
 
     # Test that always a single state is active
@@ -69,8 +69,8 @@ end
         reformer_test(m, case, params_used)
 
         # Extract the required parameters
-        𝒯 = case[:T]
-        ref = case[:nodes][3]
+        𝒯 = get_time_struct(case)
+        ref = get_nodes(case)[3]
         ops = collect(𝒯)
 
         # Test that the system is limited by the minimum and maximum usage
@@ -104,8 +104,8 @@ end
         reformer_test(m, case, params_used)
 
         # Extract the required parameters
-        𝒯 = case[:T]
-        ref = case[:nodes][3]
+        𝒯 = get_time_struct(case)
+        ref = get_nodes(case)[3]
         ops = collect(𝒯)
 
         # Test that the system is limited by the minimum and maximum usage
@@ -130,8 +130,8 @@ end
         reformer_test(m, case, params_used)
 
         # Extract the required parameters
-        𝒯 = case[:T]
-        ref = case[:nodes][3]
+        𝒯 = get_time_struct(case)
+        ref = get_nodes(case)[3]
         ops = collect(𝒯)
 
         # Test that the system is behavioung exactly the way it should
@@ -169,8 +169,8 @@ end
         reformer_test(m, case, params_used)
 
         # Extract the required parameters
-        𝒯 = case[:T]
-        ref = case[:nodes][3]
+        𝒯 = get_time_struct(case)
+        ref = get_nodes(case)[3]
         ops = collect(𝒯)
 
         # Test that the system is behavioung exactly the way it should
@@ -222,8 +222,8 @@ end
         reformer_test(m, case, params_used)
 
         # Extract the required parameters
-        𝒯 = case[:T]
-        ref = case[:nodes][3]
+        𝒯 = get_time_struct(case)
+        ref = get_nodes(case)[3]
         ops = collect(𝒯)
 
         # Test that the system is behavioung exactly the way it should

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -111,13 +111,8 @@ function build_run_electrolyzer_model(params; cap=FixedProfile(100))
         Direct("l4", Central_node, End_hydrogen_consumer)
     ]
 
-    # Step 6: Include all parameters in a single dictionary
-    case = Dict(
-        :T => T,
-        :products => products,
-        :nodes => Array{EMB.Node}(nodes),
-        :links => Array{EMB.Link}(links),
-    )
+    # Step 6: Include all parameters in the input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
     # B Formulating and running the optimization problem
     if EMI.has_investment(PEM_electrolyzer)
@@ -161,8 +156,8 @@ the previous usage with stack replacement is correctly calculated.
 function penalty_test(m, case, params)
 
     # Reassign types and variables
-    elect = case[:nodes][3]
-    𝒯 = case[:T]
+    elect = get_nodes(case)[3]
+    𝒯 = get_time_struct(case)
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
     penalty = m[:elect_efficiency_penalty]
     stack_replace = m[:elect_stack_replace_b][elect, :]
@@ -311,13 +306,8 @@ function build_run_reformer_model(params)
     end
 
 
-    # Step 7: Include all parameters in a single dictionary
-    case = Dict(
-        :T => T,
-        :products => products,
-        :nodes => Array{EMB.Node}(nodes),
-        :links => Array{EMB.Link}(links),
-    )
+    # Step 7: Include all parameters in the input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
     # B Formulating and running the optimization problem
 
@@ -352,8 +342,8 @@ Test function for analysing that the reformer is producing at least in a single 
 """
 function reformer_test(m, case, params)
 
-    𝒯 = case[:T]
-    ref = case[:nodes][3]
+    𝒯 = get_time_struct(case)
+    ref = get_nodes(case)[3]
 
     @test termination_status(m) == MOI.OPTIMAL
     @test sum(value.(m[:ref_on_b][ref, t]) for t ∈ 𝒯) > 0
@@ -466,13 +456,8 @@ function build_run_h2_storage_model(params)
         Direct("h2_source-h2_sink", h2_source, h2_sink)
     ]
 
-    # Step 7: Include all parameters in a single dictionary
-    case = Dict(
-        :T => T,
-        :products => products,
-        :nodes => Array{EMB.Node}(nodes),
-        :links => Array{EMB.Link}(links),
-    )
+    # Step 7: Include all parameters in parameters in the input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
 
     # B Formulating and running the optimization problem
     model = OperationalModel(


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [`v0.9.0 EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0) 

The adjustments required minor changes in the design of the individual tests and examples. It did not require any changes to the code itself.