### PR TITLE
Fixed a bug when using `OperationalScenarios` with `Reformer`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Unversioned
 
+### Bugfix
+
+* Fixed a bug when using `OperationalScenarios` with `Reformer` nodes.
+
+### Other
+
 * Renamed `Data` to `ExtensionData` as introduced in [`EnergyModelsBase` v0.9.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.1).
 
 ## Version 0.8.1 (2025-02-10)

--- a/src/constraints/reformer.jl
+++ b/src/constraints/reformer.jl
@@ -253,7 +253,7 @@ function constraints_state_time_iter(
     for t_scp ∈ opscenarios(per)
         t_last = last(t_scp)
         ts = t_scp.operational.operational
-        constraiteants_state_time_iter(m, n, t_scp, t_last, ts, modeltype)
+        constraints_state_time_iter(m, n, t_scp, t_last, ts, modeltype)
     end
 end
 function constraints_state_time_iter(

--- a/test/test_electrolyzer.jl
+++ b/test/test_electrolyzer.jl
@@ -35,7 +35,7 @@ end
 @testset "Electrolyzer - Investment extension test" begin
     # Modifying the input parameters
     params_inv = deepcopy(params_dict)
-    params_inv[:num_op] = 2000
+    params_inv[:num_op] = 20
     params_inv[:deficit_cost] = FixedProfile(1e4)
     params_inv[:data] = ExtensionData[SingleInvData(
         FixedProfile(4e5),


### PR DESCRIPTION
The function call used within the iteration function for `OperationalScenarios` was misspelled. This was not identified as there are currently no tests for this.

I am currently reworking the test setup and push these today. Hence, I did not spend time to include tests regarding this topic in this MR.