### PR TITLE
Fix/Investment model without InvData for AbstractElectrolyzer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unversioned
+
+### Bugfix
+
+* Fixed a bug when using `InvestmentModel` without investment data for `AbstractElectrolyzer` nodes.
+
 ## Version 0.8.2 (2025-06-27)
 
 ### Bugfix

--- a/docs/src/nodes/electrolyzer.md
+++ b/docs/src/nodes/electrolyzer.md
@@ -145,7 +145,7 @@ These variables are:
 
 ### [Constraints](@id nodes-elec-math-con)
 
-The following sections omit the direction inclusion of the vector of electrolyzer nodes.
+The following sections omit the direct inclusion of the vector of electrolyzer nodes.
 Instead, it is implicitly assumed that the constraints are valid ``\forall n_{el} ∈ N^{EL}``, that is both [`SimpleElectrolyzer`](@ref) and [`Electrolyzer`](@ref) types if not stated differently.
 In addition, all constraints are valid ``\forall t \in T`` (that is in all operational periods) or ``\forall t_{inv} \in T^{Inv}`` (that is in all investment periods).
 
@@ -182,7 +182,7 @@ These standard constraints are:
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
 - `constraints_data`:\
-  This function is only called for specified data of the reformer, see above.
+  This function is only called for specified data of the electrolyzer, see above.
 
 The [`SimpleElectrolyzer`](@ref) node utilizes in addition the default function `constraints_flow_out`:
 

--- a/docs/src/nodes/h2_storage.md
+++ b/docs/src/nodes/h2_storage.md
@@ -81,7 +81,7 @@ Boths nodes have the following fields:
   As a consequence of its introduction, it is not possible to specify a `discharge` capacity to the storage node.
 - **`level_charge::Float64`**:\
   The level to charge ratio specifies the maximum allowed storage level capacity as a ratio of the charging capacity.
-  The implementation is rquired to avoid large pressure changes in the vessel in a short period.
+  The implementation is requiredto avoid large pressure changes in the vessel in a short period.
 
 !!! note "Allowed values"
     Both ratios have to be positive.
@@ -229,12 +229,12 @@ additional constraints are introduced to account for the introduced limits throu
 
 ```math
 \begin{aligned}
-\texttt{stor\__discharge\_use}[n, t] & \leq discharge\_charge(n) \texttt{stor\_charge\_use}[n, t] \\
-\texttt{stor\_charge\_inst}[n, t] level\_charge(n) & \leq \texttt{stor\_level\_inst}[n, t]
+\texttt{stor\_discharge\_use}[n, t] & \leq discharge\_charge(n) \times \texttt{stor\_charge\_use}[n, t] \\
+level\_charge(n) \times \texttt{stor\_charge\_inst}[n, t] & \leq \texttt{stor\_level\_inst}[n, t]
 \end{aligned}
 ```
 
-The second constraint also limitsthe potential for investments in the charge capacity through the different constraints introduced in `EnergyModelsBase`.
+The second constraint also limits the potential for investments in the charge capacity through the different constraints introduced in `EnergyModelsBase`.
 
 The function `constraints_flow_in` is different for [`SimpleHydrogenStorage`](@ref) and [`HydrogenStorage`](@ref).
 [`SimpleHydrogenStorage`](@ref) nodes utilize the standard method.

--- a/docs/src/nodes/reformer.md
+++ b/docs/src/nodes/reformer.md
@@ -114,7 +114,7 @@ A value of 1 corresponds to an operation in the given stage while a value of 0 i
 
 ### [Constraints](@id nodes-ref-math-con)
 
-The following sections omit the direction inclusion of the vector of reformer nodes.
+The following sections omit the direct inclusion of the vector of reformer nodes.
 Instead, it is implicitly assumed that the constraints are valid ``\forall n_{ref} ∈ N^{Ref}`` for all [`Reformer`](@ref) types if not stated differently.
 In addition, all constraints are valid ``\forall t \in T`` (that is in all operational periods) or ``\forall t_{inv} \in T^{Inv}`` (that is in all investment periods).
 


### PR DESCRIPTION
When we utilized an investment model without providing investment data for both `Electrolyzer` and `SimpleElectrolyzer` ,we experienced a bug as some of the utility functions in the extension did not check whether the node had in fact investment data.

This is fixed in this PR.