### PR TITLE
Fix/Upper bound in linear reformulation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # Release Notes
 
-## Unversioned
+## Version 0.8.3 (2025-08-17)
 
 ### Bugfix
 
 * Fixed a bug when using `InvestmentModel` without investment data for `AbstractElectrolyzer` nodes.
+* Fixed a bug which provided a wrong upper bound for the linear reformulation for `AbstractElectrolyzer` nodes.
+  This bug essentially forces stack replacement when the maximum capacity was small.
 
 ## Version 0.8.2 (2025-06-27)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsHydrogen"
 uuid = "44855f8b-b147-4985-ac18-48817d03c548"
 authors = ["Julian Straus <Julian.Straus@sintef.no>, Avinash Subramanian"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/src/constraints/electrolyzer.jl
+++ b/src/constraints/electrolyzer.jl
@@ -69,7 +69,7 @@ function constraints_usage_sp(
         m[:elect_use_sp][n, t_inv_prev] * duration_strat(t_inv_prev)
     )
     # Define the upper bound
-    ub = capacity_max(n, t_inv, modeltype)
+    ub = stack_lifetime(n)/1000
 
     # Constraints for the linear reformulation. The constraints are based on the
     # McCormick envelopes which result in an exact reformulation for the multiplication


### PR DESCRIPTION
The upper bound in the linear reformulation for stack replacement was in the current version based on the maximum capacity instead of the maximum stack lifetime. This lead to situations with small capacities (less than the stack lifetime divided by 1000) to early stack replacement.