### PR TITLE
Adjustment to EMB v0.10 and EMI v0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 0.9.0 (2026-04-14)
+
+### Breaking changes
+
+* Adjusted to the changes introduced in [`EnergyModelsInvestments` 0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0):
+  * Breaking change required as early retirement is now allowed.
+  * Early retirement can change the model behavior.
+
 ## Version 0.8.3 (2025-08-17)
 
 ### Bugfix

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsHydrogen"
 uuid = "44855f8b-b147-4985-ac18-48817d03c548"
 authors = ["Julian Straus <Julian.Straus@sintef.no>, Avinash Subramanian"]
-version = "0.8.3"
+version = "0.9.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -15,8 +15,8 @@ EnergyModelsInvestments = "fca3f8eb-b383-437d-8e7b-aac76bb2004f"
 EMIExt = "EnergyModelsInvestments"
 
 [compat]
-EnergyModelsBase = "0.9.1"
-EnergyModelsInvestments = "0.8"
+EnergyModelsBase = "0.10"
+EnergyModelsInvestments = "0.9"
 JuMP = "1.5"
 julia = "1.10"
 TimeStruct = "0.9"


### PR DESCRIPTION
This PR increases the dependency version number due to the new version [v0.10.0 of `EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0) and [v0.9.0 of `EnergyModelsInvestments`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0).

The adjustments did not require any changes except for dependency updates. It is however prudent to do a major version increase to maintain the potential for bug fixes in the previous version. In addition, the behavior may change when investments are included.

> [!IMPORTANT]  
> There will be an additional PR before registering the new version. This additional PR focuses on improvement of the documentation.